### PR TITLE
handle address annotation of slices

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -1061,9 +1061,32 @@ var mapElementCycles = []struct {
 }
 `,
 	},
+	// The following test is to confirm that the recursion detection
+	// is not overly zealous by missing identifying the address of slices.
+	// This is https://github.com/kortschak/utter/issues/12.
+	{
+		v: map[interface{}][]interface{}{
+			"outer": []interface{}{
+				map[interface{}]interface{}{
+					"inner": []interface{}{"value"},
+				},
+			},
+		},
+		want: `map[interface{}][]interface{}{
+ string("outer"): []interface{}{
+  map[interface{}]interface{}{
+   string("inner"): []interface{}{
+    string("value"),
+   },
+  },
+ },
+}
+`,
+	},
 }
 
 // https://github.com/kortschak/utter/issues/5
+// https://github.com/kortschak/utter/issues/12
 func TestIssue5Maps(t *testing.T) {
 	for _, test := range mapElementCycles {
 		w := newLimitedWriter(512)


### PR DESCRIPTION
The current code breaks `interface{}` introspection for values that have already been seen as another pointer. Still looking into that.

Fixes #12.