### PR TITLE
fix false positive detection of cycles with slice in first field of struct

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -412,6 +412,10 @@ func (d *dumpState) dump(v reflect.Value, wasPtr, static bool, addr uintptr) {
 			d.w.Write(closeParenBytes)
 			break
 		}
+		if v.Len() == 0 {
+			d.dumpSlice(v)
+			break
+		}
 		// Remove pointers at or below the current depth from map used to detect
 		// circular refs.
 		for k, depth := range d.pointers {
@@ -419,6 +423,7 @@ func (d *dumpState) dump(v reflect.Value, wasPtr, static bool, addr uintptr) {
 				delete(d.pointers, k)
 			}
 		}
+		addr = v.Index(0).Addr().Pointer()
 		if pd, ok := d.pointers[addr]; ok && pd < d.depth {
 			d.w.Write(circularBytes)
 			break

--- a/dump_test.go
+++ b/dump_test.go
@@ -887,9 +887,7 @@ var sliceElementCycles = []struct {
 		// the cycle as the initial v seen by utter.Dump was not
 		// addressable.
 		want: `[]interface{}{
- []interface{}{
-  []interface{}(<already shown>),
- },
+ []interface{}(<already shown>),
 }
 `,
 	},
@@ -900,9 +898,7 @@ var sliceElementCycles = []struct {
 			return &r
 		}(),
 		want: `&[]interface{}{
- []interface{}{
-  []interface{}(<already shown>),
- },
+ []interface{}(<already shown>),
 }
 `,
 	},
@@ -913,7 +909,7 @@ var sliceElementCycles = []struct {
 			return &r
 		}(),
 		want: `&[]interface{}{
- (*[]interface{})(<already shown>),
+ &[]interface{}(<already shown>),
 }
 `,
 	},
@@ -948,7 +944,25 @@ var sliceElementCycles = []struct {
 			return &r
 		}(),
 		want: `&utter_test.recurrence{
- v: []interface{}(<already shown>),
+ v: []interface{}{
+  utter_test.recurrence{
+   v: []interface{}(<already shown>),
+  },
+ },
+}
+`,
+	},
+	{
+		v: func() interface{} {
+			type container struct {
+				v []int
+			}
+			return &container{[]int{1}}
+		}(),
+		want: `&utter_test.container{
+ v: []int{
+  int(1),
+ },
 }
 `,
 	},

--- a/spew_test.go
+++ b/spew_test.go
@@ -182,7 +182,7 @@ func initSpewTests() {
 		{comPtrDefault, fCSFdump, spp, fmt.Sprintf("&&struct { *int } /*%p->%p*/ {\n int: &int /*%p*/ (10),\n}\n", spp, sp, v)},
 		{comPtrDefault, fCSFdump, c, fmt.Sprintf("[]interface{}{\n"+
 			" int( /*%p*/ 5),\n int( /*%p*/ 5),\n"+
-			" &int /*%[1]p*/ (5),\n &int /*%p*/ (5),\n}\n", &c[0], &c[1])},
+			" (*interface{}) /*%[1]p*/ (<already shown>),\n &int /*%p*/ (5),\n}\n", &c[0], &c[1])},
 		{comPtrDefault, fCSFdump, d, fmt.Sprintf("&struct { a [2]int; p *int } /*%p*/ {\n"+
 			" a: [2]int{\n  int(0),\n"+
 			"  int( /*%p*/ 10),\n },\n"+
@@ -193,7 +193,7 @@ func initSpewTests() {
 			" int(1): []interface{}{\n"+
 			"  int( /*%p*/ 5),\n"+
 			"  int( /*%p*/ 5),\n"+
-			"  &int /*%[1]p*/ (5),\n"+
+			"  (*interface{}) /*%[1]p*/ (<already shown>),\n"+
 			"  &int /*%p*/ (5),\n },\n}\n", &c[0], &c[1])},
 		{bs8Default, fCSFdump, []byte{1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3}, "[]uint8{\n" +
 			" 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x01, 0x02, // |........|\n" +


### PR DESCRIPTION
The fix in #7 caused a false positive for slices in the first field of a struct because the address was not correctly found for the element instead of the slice header. This fixes that.

Updates #5.